### PR TITLE
🛟 Arrumador: Fix Go version mismatch and robustify linter setup

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/lucasew/readability-web
 
-go 1.24.7
+go 1.25.7
 
 require (
 	codeberg.org/readeck/go-readability/v2 v2.1.0

--- a/mise.toml
+++ b/mise.toml
@@ -1,7 +1,6 @@
 [tools]
 bun = "1.3.8"
 go = "1.25.7"
-golangci-lint = "1.64.8"
 
 [tasks.dev]
 run = "bunx vercel dev"
@@ -27,7 +26,7 @@ depends = ["lint:*"]
 description = "Run all linters"
 
 [tasks."lint:go"]
-run = "golangci-lint run"
+run = "go run github.com/golangci/golangci-lint/cmd/golangci-lint@v1.64.8 run"
 description = "Run Go linter"
 
 [tasks."lint:prettier"]
@@ -39,7 +38,7 @@ depends = ["fmt:*"]
 description = "Format all files"
 
 [tasks."fmt:go"]
-run = "golangci-lint run --fix"
+run = "go run github.com/golangci/golangci-lint/cmd/golangci-lint@v1.64.8 run --fix"
 description = "Format Go files"
 
 [tasks."fmt:prettier"]


### PR DESCRIPTION
- **Align `go.mod`**: Updated to Go 1.25.7 to match `mise.toml` and recent dependency updates.
- **Robust Linter Setup**: Modified `mise.toml` to execute `golangci-lint` using `go run ...`. This avoids `mise install` failures caused by GitHub API rate limits when fetching release tags, ensuring a more reliable CI process.
- **CI Verification**: Validated that `mise run ci` passes with the new configuration.

---
*PR created automatically by Jules for task [14794979233211407019](https://jules.google.com/task/14794979233211407019) started by @lucasew*