### PR TITLE
🛟 Arrumador: Standardize mise tasks and CI workflow

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,3 @@
-codeberg.org/readeck/go-readability/v2 v2.1.0 h1:1T72CzXu4nrZr/DA1A5fAkaVsTMx/LSALPkSSZY+NWI=
-codeberg.org/readeck/go-readability/v2 v2.1.0/go.mod h1:x3WG9GpWWnkRb7ajP1NmOKSHbafxNUb736lrDZXeXrs=
 codeberg.org/readeck/go-readability/v2 v2.1.1 h1:1tEwxFuUqDRP5JABzDHXGWRx5p9S7TElS3U8qQwXC5Y=
 codeberg.org/readeck/go-readability/v2 v2.1.1/go.mod h1:x3WG9GpWWnkRb7ajP1NmOKSHbafxNUb736lrDZXeXrs=
 github.com/andybalholm/cascadia v1.3.3 h1:AG2YHrzJIm4BZ19iwJ/DAua6Btl3IwJX+VI4kktS1LM=

--- a/mise.toml
+++ b/mise.toml
@@ -19,8 +19,12 @@ run = "bun install"
 description = "Install Bun dependencies"
 
 [tasks.test]
-run = "go test ./..."
+depends = ["test:*"]
 description = "Run tests"
+
+[tasks."test:go"]
+run = "go test ./..."
+description = "Run Go tests"
 
 [tasks.lint]
 depends = ["lint:*"]
@@ -47,9 +51,13 @@ run = "bunx prettier --write ."
 description = "Format with Prettier"
 
 [tasks.codegen]
-run = "echo 'No codegen tasks'"
+depends = ["codegen:*"]
 description = "Run code generation"
 
+[tasks."codegen:go"]
+run = "go mod tidy"
+description = "Run Go codegen"
+
 [tasks.ci]
-depends = ["install", "lint", "test"]
+depends = ["lint", "test"]
 description = "Run CI pipeline"


### PR DESCRIPTION
Updated `mise.toml` to standardize tasks for `test`, `codegen`, and `ci` according to project guidelines. Added `test:go` and `codegen:go`. `go.sum` was updated via `mise run codegen`.

---
*PR created automatically by Jules for task [11895532304848268118](https://jules.google.com/task/11895532304848268118) started by @lucasew*