### PR TITLE
🔇 Denoiser: Add rule for Vercel CI release steps

### DIFF
--- a/.jules/CONSISTENTLY_IGNORED.md
+++ b/.jules/CONSISTENTLY_IGNORED.md
@@ -1,0 +1,5 @@
+## IGNORE: No Release/Artifact Steps in CI for Vercel
+
+**- Pattern:** Adding `Release` or `Artifacts` jobs/steps to `.github/workflows/autorelease.yml`.
+**- Justification:** Vercel deployments manage their own releases. The `autorelease.yml` workflow should strictly handle CI checks (lint/test) and tag creation, but not artifact uploads or GitHub Releases modification, as these are intentionally omitted for Vercel-based projects.
+**- Files Affected:** `.github/workflows/autorelease.yml`


### PR DESCRIPTION
Analyzed rejected pull requests to identify consistent patterns. Found that PR #126 was rejected because it attempted to add release and artifact upload steps to the CI workflow, which contradicts the Vercel deployment strategy.

Created `.jules/CONSISTENTLY_IGNORED.md` and added the "No Release/Artifact Steps in CI for Vercel" rule. Verified the file content and formatting.

---
*PR created automatically by Jules for task [7101100878418972698](https://jules.google.com/task/7101100878418972698) started by @lucasew*