### PR TITLE
🛡️ Sentinel: [HIGH] Fix XSS via un-sanitized go-readability output

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -13,4 +13,5 @@
 **Learning:** `ip.IsPrivate()` and `ip.IsLoopback()` are not sufficient to block all local traffic. The concept of "Unspecified" addresses (all zeros) must also be explicitly handled when validating IPs for SSRF protection in Go.
 
 **Prevention:** When implementing a safe dialer to prevent SSRF, always include `ip.IsUnspecified()` in the list of blocked IP characteristics, in addition to private, loopback, and link-local addresses.
+
 - 2024-03-01: [XSS via go-readability] go-readability output is not safe for direct rendering and must be sanitized using bluemonday before outputting HTML.

--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -13,3 +13,4 @@
 **Learning:** `ip.IsPrivate()` and `ip.IsLoopback()` are not sufficient to block all local traffic. The concept of "Unspecified" addresses (all zeros) must also be explicitly handled when validating IPs for SSRF protection in Go.
 
 **Prevention:** When implementing a safe dialer to prevent SSRF, always include `ip.IsUnspecified()` in the list of blocked IP characteristics, in addition to private, loopback, and link-local addresses.
+- 2024-03-01: [XSS via go-readability] go-readability output is not safe for direct rendering and must be sanitized using bluemonday before outputting HTML.

--- a/api/index.go
+++ b/api/index.go
@@ -321,10 +321,10 @@ func Handler(w http.ResponseWriter, r *http.Request) {
 type formatHandler func(w http.ResponseWriter, article readability.Article, buf *bytes.Buffer)
 
 /**
- * sanitizeHTML strips malicious content from an HTML string.
+ * sanitizeHTML strips malicious content from an HTML byte slice.
  */
-func sanitizeHTML(html string) string {
-	return HTMLSanitizer.Sanitize(html)
+func sanitizeHTML(content []byte) []byte {
+	return HTMLSanitizer.SanitizeBytes(content)
 }
 
 /**
@@ -334,7 +334,7 @@ func sanitizeHTML(html string) string {
 func formatHTML(w http.ResponseWriter, article readability.Article, contentBuf *bytes.Buffer) {
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
 
-	sanitizedContent := sanitizeHTML(contentBuf.String())
+	sanitizedContent := sanitizeHTML(contentBuf.Bytes())
 
 	// inject safe HTML content
 	data := struct {
@@ -357,8 +357,8 @@ func formatHTML(w http.ResponseWriter, article readability.Article, contentBuf *
 func formatMarkdown(w http.ResponseWriter, _ readability.Article, buf *bytes.Buffer) {
 	w.Header().Set("Content-Type", "text/markdown")
 
-	sanitizedContent := sanitizeHTML(buf.String())
-	sanitizedBuf := bytes.NewBufferString(sanitizedContent)
+	sanitizedContent := sanitizeHTML(buf.Bytes())
+	sanitizedBuf := bytes.NewBuffer(sanitizedContent)
 
 	if err := godown.Convert(w, sanitizedBuf, nil); err != nil {
 		log.Printf("error converting to markdown: %v", err)
@@ -372,11 +372,11 @@ func formatMarkdown(w http.ResponseWriter, _ readability.Article, buf *bytes.Buf
 func formatJSON(w http.ResponseWriter, article readability.Article, buf *bytes.Buffer) {
 	w.Header().Set("Content-Type", "application/json")
 
-	sanitizedContent := sanitizeHTML(buf.String())
+	sanitizedContent := sanitizeHTML(buf.Bytes())
 
 	if err := json.NewEncoder(w).Encode(map[string]string{
 		"title":   article.Title(),
-		"content": sanitizedContent,
+		"content": string(sanitizedContent),
 	}); err != nil {
 		log.Printf("error encoding json: %v", err)
 	}
@@ -388,9 +388,9 @@ func formatJSON(w http.ResponseWriter, article readability.Article, buf *bytes.B
 func formatText(w http.ResponseWriter, _ readability.Article, buf *bytes.Buffer) {
 	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
 
-	sanitizedContent := sanitizeHTML(buf.String())
+	sanitizedContent := sanitizeHTML(buf.Bytes())
 
-	if _, err := w.Write([]byte(sanitizedContent)); err != nil {
+	if _, err := w.Write(sanitizedContent); err != nil {
 		log.Printf("error writing text response: %v", err)
 	}
 }

--- a/api/index.go
+++ b/api/index.go
@@ -26,6 +26,7 @@ import (
 
 	"codeberg.org/readeck/go-readability/v2"
 	"github.com/mattn/godown"
+	"github.com/microcosm-cc/bluemonday"
 	"golang.org/x/net/html"
 )
 
@@ -77,6 +78,15 @@ var (
 	 * requests without the need to create new parser instances.
 	 */
 	ReadabilityParser = readability.NewParser()
+
+	/**
+	 * HTMLSanitizer is the shared instance of the bluemonday HTML sanitizer.
+	 *
+	 * It uses the UGCPolicy to allow common, safe HTML tags and attributes
+	 * while stripping out potentially malicious content like scripts and
+	 * event handlers (e.g., onclick, onerror) to prevent XSS attacks.
+	 */
+	HTMLSanitizer = bluemonday.UGCPolicy()
 
 	// httpClient used for fetching remote articles with timeouts and redirect policy
 	httpClient = &http.Client{
@@ -311,18 +321,28 @@ func Handler(w http.ResponseWriter, r *http.Request) {
 type formatHandler func(w http.ResponseWriter, article readability.Article, buf *bytes.Buffer)
 
 /**
+ * sanitizeHTML strips malicious content from an HTML string.
+ */
+func sanitizeHTML(html string) string {
+	return HTMLSanitizer.Sanitize(html)
+}
+
+/**
  * formatHTML renders the article using the standard HTML template.
  * This is the default view for human consumption.
  */
 func formatHTML(w http.ResponseWriter, article readability.Article, contentBuf *bytes.Buffer) {
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+
+	sanitizedContent := sanitizeHTML(contentBuf.String())
+
 	// inject safe HTML content
 	data := struct {
 		Title   string
 		Content template.HTML
 	}{
 		Title:   article.Title(),
-		Content: template.HTML(contentBuf.String()),
+		Content: template.HTML(sanitizedContent),
 	}
 	if err := DefaultTemplate.Execute(w, data); err != nil {
 		// at this point, we can't write a JSON error, so we log it
@@ -336,7 +356,11 @@ func formatHTML(w http.ResponseWriter, article readability.Article, contentBuf *
  */
 func formatMarkdown(w http.ResponseWriter, _ readability.Article, buf *bytes.Buffer) {
 	w.Header().Set("Content-Type", "text/markdown")
-	if err := godown.Convert(w, buf, nil); err != nil {
+
+	sanitizedContent := sanitizeHTML(buf.String())
+	sanitizedBuf := bytes.NewBufferString(sanitizedContent)
+
+	if err := godown.Convert(w, sanitizedBuf, nil); err != nil {
 		log.Printf("error converting to markdown: %v", err)
 	}
 }
@@ -347,9 +371,12 @@ func formatMarkdown(w http.ResponseWriter, _ readability.Article, buf *bytes.Buf
  */
 func formatJSON(w http.ResponseWriter, article readability.Article, buf *bytes.Buffer) {
 	w.Header().Set("Content-Type", "application/json")
+
+	sanitizedContent := sanitizeHTML(buf.String())
+
 	if err := json.NewEncoder(w).Encode(map[string]string{
 		"title":   article.Title(),
-		"content": buf.String(),
+		"content": sanitizedContent,
 	}); err != nil {
 		log.Printf("error encoding json: %v", err)
 	}
@@ -360,7 +387,10 @@ func formatJSON(w http.ResponseWriter, article readability.Article, buf *bytes.B
  */
 func formatText(w http.ResponseWriter, _ readability.Article, buf *bytes.Buffer) {
 	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
-	if _, err := w.Write(buf.Bytes()); err != nil {
+
+	sanitizedContent := sanitizeHTML(buf.String())
+
+	if _, err := w.Write([]byte(sanitizedContent)); err != nil {
 		log.Printf("error writing text response: %v", err)
 	}
 }

--- a/api/xss_test.go
+++ b/api/xss_test.go
@@ -31,9 +31,9 @@ func TestXSSHTMLSanitization(t *testing.T) {
 		t.Fatalf("failed to render html: %v", err)
 	}
 
-	sanitizedHTML := sanitizeHTML(buf.String())
+	sanitizedHTML := sanitizeHTML(buf.Bytes())
 
-	if strings.Contains(sanitizedHTML, "<script>") || strings.Contains(sanitizedHTML, "onerror") {
+	if strings.Contains(string(sanitizedHTML), "<script>") || strings.Contains(string(sanitizedHTML), "onerror") {
 		t.Errorf("HTML was not sanitized correctly: %s", sanitizedHTML)
 	}
 }

--- a/api/xss_test.go
+++ b/api/xss_test.go
@@ -1,0 +1,39 @@
+package handler
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+// mockArticle implements readability.Article for testing
+type mockArticle struct {
+	title string
+	html  string
+}
+
+func (m mockArticle) Title() string {
+	return m.title
+}
+
+func (m mockArticle) RenderHTML(w *bytes.Buffer) error {
+	w.WriteString(m.html)
+	return nil
+}
+
+func TestXSSHTMLSanitization(t *testing.T) {
+	// A mock article with malicious content
+	maliciousHTML := `<p>Hello</p><script>alert("xss")</script><img src="x" onerror="alert('xss')">`
+	article := mockArticle{title: "Test", html: maliciousHTML}
+
+	buf := &bytes.Buffer{}
+	if err := article.RenderHTML(buf); err != nil {
+		t.Fatalf("failed to render html: %v", err)
+	}
+
+	sanitizedHTML := sanitizeHTML(buf.String())
+
+	if strings.Contains(sanitizedHTML, "<script>") || strings.Contains(sanitizedHTML, "onerror") {
+		t.Errorf("HTML was not sanitized correctly: %s", sanitizedHTML)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -11,10 +11,13 @@ require (
 require (
 	github.com/andybalholm/cascadia v1.3.3 // indirect
 	github.com/araddon/dateparse v0.0.0-20210429162001-6b43995a97de // indirect
+	github.com/aymerick/douceur v0.2.0 // indirect
 	github.com/clipperhouse/stringish v0.1.1 // indirect
 	github.com/clipperhouse/uax29/v2 v2.3.0 // indirect
 	github.com/go-shiori/dom v0.0.0-20230515143342-73569d674e1c // indirect
 	github.com/gogs/chardet v0.0.0-20211120154057-b7413eaefb8f // indirect
+	github.com/gorilla/css v1.0.1 // indirect
 	github.com/mattn/go-runewidth v0.0.19 // indirect
+	github.com/microcosm-cc/bluemonday v1.0.27 // indirect
 	golang.org/x/text v0.32.0 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.24.7
 require (
 	codeberg.org/readeck/go-readability/v2 v2.1.1
 	github.com/mattn/godown v0.0.1
+	github.com/microcosm-cc/bluemonday v1.0.27
 	golang.org/x/net v0.48.0
 )
 
@@ -18,6 +19,5 @@ require (
 	github.com/gogs/chardet v0.0.0-20211120154057-b7413eaefb8f // indirect
 	github.com/gorilla/css v1.0.1 // indirect
 	github.com/mattn/go-runewidth v0.0.19 // indirect
-	github.com/microcosm-cc/bluemonday v1.0.27 // indirect
 	golang.org/x/text v0.32.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -6,6 +6,8 @@ github.com/andybalholm/cascadia v1.3.3 h1:AG2YHrzJIm4BZ19iwJ/DAua6Btl3IwJX+VI4kk
 github.com/andybalholm/cascadia v1.3.3/go.mod h1:xNd9bqTn98Ln4DwST8/nG+H0yuB8Hmgu1YHNnWw0GeA=
 github.com/araddon/dateparse v0.0.0-20210429162001-6b43995a97de h1:FxWPpzIjnTlhPwqqXc4/vE0f7GvRjuAsbW+HOIe8KnA=
 github.com/araddon/dateparse v0.0.0-20210429162001-6b43995a97de/go.mod h1:DCaWoUhZrYW9p1lxo/cm8EmUOOzAPSEZNGF2DK1dJgw=
+github.com/aymerick/douceur v0.2.0 h1:Mv+mAeH1Q+n9Fr+oyamOlAkUNPWPlA8PPGR0QAaYuPk=
+github.com/aymerick/douceur v0.2.0/go.mod h1:wlT5vV2O3h55X9m7iVYN0TBM0NH/MmbLnd30/FjWUq4=
 github.com/clipperhouse/stringish v0.1.1 h1:+NSqMOr3GR6k1FdRhhnXrLfztGzuG+VuFDfatpWHKCs=
 github.com/clipperhouse/stringish v0.1.1/go.mod h1:v/WhFtE1q0ovMta2+m+UbpZ+2/HEXNWYXQgCt4hdOzA=
 github.com/clipperhouse/uax29/v2 v2.3.0 h1:SNdx9DVUqMoBuBoW3iLOj4FQv3dN5mDtuqwuhIGpJy4=
@@ -18,12 +20,16 @@ github.com/go-shiori/dom v0.0.0-20230515143342-73569d674e1c/go.mod h1:oVDCh3qjJM
 github.com/gogs/chardet v0.0.0-20211120154057-b7413eaefb8f h1:3BSP1Tbs2djlpprl7wCLuiqMaUh5SJkkzI2gDs+FgLs=
 github.com/gogs/chardet v0.0.0-20211120154057-b7413eaefb8f/go.mod h1:Pcatq5tYkCW2Q6yrR2VRHlbHpZ/R4/7qyL1TCF7vl14=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+github.com/gorilla/css v1.0.1 h1:ntNaBIghp6JmvWnxbZKANoLyuXTPZ4cAMlo6RyhlbO8=
+github.com/gorilla/css v1.0.1/go.mod h1:BvnYkspnSzMmwRK+b8/xgNPLiIuNZr6vbZBTPQ2A3b0=
 github.com/mattn/go-runewidth v0.0.8/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
 github.com/mattn/go-runewidth v0.0.10/go.mod h1:RAqKPSqVFrSLVXbA8x7dzmKdmGzieGRCM46jaSJTDAk=
 github.com/mattn/go-runewidth v0.0.19 h1:v++JhqYnZuu5jSKrk9RbgF5v4CGUjqRfBm05byFGLdw=
 github.com/mattn/go-runewidth v0.0.19/go.mod h1:XBkDxAl56ILZc9knddidhrOlY5R/pDhgLpndooCuJAs=
 github.com/mattn/godown v0.0.1 h1:39uk50ufLVQFs0eapIJVX5fCS74a1Fs2g5f1MVqIHdE=
 github.com/mattn/godown v0.0.1/go.mod h1:/ivCKurgV/bx6yqtP/Jtc2Xmrv3beCYBvlfAUl4X5g4=
+github.com/microcosm-cc/bluemonday v1.0.27 h1:MpEUotklkwCSLeH+Qdx1VJgNqLlpY2KXwXFM08ygZfk=
+github.com/microcosm-cc/bluemonday v1.0.27/go.mod h1:jFi9vgW+H7c3V0lb6nR74Ib/DIB5OBs92Dimizgw2cA=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/rivo/uniseg v0.1.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,3 @@
-codeberg.org/readeck/go-readability/v2 v2.1.0 h1:1T72CzXu4nrZr/DA1A5fAkaVsTMx/LSALPkSSZY+NWI=
-codeberg.org/readeck/go-readability/v2 v2.1.0/go.mod h1:x3WG9GpWWnkRb7ajP1NmOKSHbafxNUb736lrDZXeXrs=
 codeberg.org/readeck/go-readability/v2 v2.1.1 h1:1tEwxFuUqDRP5JABzDHXGWRx5p9S7TElS3U8qQwXC5Y=
 codeberg.org/readeck/go-readability/v2 v2.1.1/go.mod h1:x3WG9GpWWnkRb7ajP1NmOKSHbafxNUb736lrDZXeXrs=
 github.com/andybalholm/cascadia v1.3.3 h1:AG2YHrzJIm4BZ19iwJ/DAua6Btl3IwJX+VI4kktS1LM=


### PR DESCRIPTION
**Severity:** High
**Vulnerability:** XSS (Cross-Site Scripting). The application was taking the raw HTML output of `go-readability` and directly injecting it into the HTML template, JSON, or Markdown formats without intermediate sanitization. `go-readability` primarily cleans up document structure for reading but does not rigorously prevent all XSS vectors (e.g. event handlers like `onerror` inside allowed tags might survive).
**Impact:** A specially crafted webpage could embed malicious JavaScript that bypasses `go-readability`'s stripping. When the `articleparser` renders it, the JS would execute in the victim's browser, potentially stealing sessions, cookies, or redirecting the user.
**Fix:** Introduced the `github.com/microcosm-cc/bluemonday` library with the `UGCPolicy` (User Generated Content) to explicitly strip out any potentially malicious HTML tags and attributes. The parsed HTML content is passed through `bluemonday`'s `Sanitize()` method before being formatted as HTML, JSON, Markdown, or Text. A `sanitizeHTML` helper handles this, utilizing a pre-configured global `HTMLSanitizer`. Added a dedicated test (`api/xss_test.go`) to ensure `onerror` handlers and scripts are blocked.

**Assumptions**
- `bluemonday.UGCPolicy` strikes the right balance between preserving standard reading-oriented HTML structure while mitigating all active content (JS/CSS/Objects).
- Sanitizing during the `format*` stage is appropriate and avoids modifying the internal state of the `readability.Article` (which is useful if a raw mode is ever required).

**Alternatives Not Chosen**
- Parsing the string manually with standard regex or custom Go HTML walkers (too error-prone, XSS requires a dedicated state machine).
- Attempting to sanitize *before* readability parsing (would break go-readability's heuristic algorithms which rely on raw page structure).

**How To Pivot**
- If `UGCPolicy` is too restrictive (e.g., strips specific layout styles/data attributes the Sakura theme relies on), switch to `bluemonday.StrictPolicy` with explicit `.AllowElements(...)` overrides for required tags.

**Next Knobs**
- Modify `HTMLSanitizer` in `api/index.go` to add custom allowed tags (e.g., `.AllowAttrs("class").OnElements("span")`).
- Add tests for edge-case URL decoding XSS payloads.

---
*PR created automatically by Jules for task [15074944369555111581](https://jules.google.com/task/15074944369555111581) started by @lucasew*